### PR TITLE
WF-1119: Update templates to pass template testing

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,42 @@
+# Working on the Azure ARM Templates
+
+Here be general notes on working with Wayfinder's Azure Marketplace ARM templates.
+
+## Developer tooling
+The marketplace configuration uses Azure's ARM (Azure Resource Manager) templates, which are specified via JSON.
+
+If using VS Code, it's recommended to install the [Azure Resource Manager Tools](https://marketplace.visualstudio.com/items?itemName=msazurermtools.azurerm-vscode-tools) extension, which provides a language server, schema validation, snippets and other goodies to help write ARM templates.
+
+## Validating Template changes
+
+If making changes to the ARM templates, run the test suite in the ARM Template Testing Toolkit to make sure the templates are valid and unlikely to have issues when being submitted to the Marketplace. See [here]() for more details on the toolkit tests, but to run the tests you will need to have PowerShell installed, and the toolkit downloaded so the relevant modules can be imported into PowerShell:
+
+### Download Powershell
+
+On MacOS, the simplest way to install PowerShell is via `brew`:
+
+```shell
+$ brew install --cask powershell
+```
+
+And from here, `pwsh` will fork a new PowerShell process.
+
+>For other platforms, see [here](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.2).
+
+
+### Download the testing toolkit
+
+The ARM Template Testing Toolkit (ttk) can be downloaded [here](https://aka.ms/arm-ttk-latest) - it just needs to be downloaded and unzipped somewhere sensible.
+
+More information about the toolkit can be found at https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/test-toolkit
+
+### Run the tests
+
+Running the tests is straightforward. Ensure you are in the PowerShell (`pwsh` from Bash and friends), and in the `wayfinder-azure/arm-template` directory, then:
+
+```powershell
+# Import the testing module into PowerShell
+PS /Path/To/wayfinder-azure/arm-tamplate> Import-Module </Path/To/testing/toolkit>/arm-ttk/arm-ttk.psd1
+# Run the toolkit tests
+PS /Path/To/wayfinder-azure/arm-tamplate> Test-AzTemplate -TemplatePath .
+```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Contributing
 ---
 **We highly appreciate all contributions to Wayfinder** - whether that would be improving our documentation, identifying bugs or even proposing new features. Our [contributing guide](CONTRIBUTING.md) provides instructions on creating issues, pull requests and our contributor code of conduct.
 
+Please also see our guide for [maintainers](MAINTAINERS.md) for information about tooling and testing.
+
 Community
 ---
 Follow us on:

--- a/arm-template/README.md
+++ b/arm-template/README.md
@@ -12,6 +12,40 @@ This template deploys [Wayfinder](https://www.appvia.io/wayfinder). Wayfinder pr
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fappvia%2Fwayfinder-azure%2Fmaster%2Farm-template%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fappvia%2Fwayfinder-azure%2Fmaster%2Farm-template%2FcreateUiDefinition.json" rel="nofollow"><img src="https://aka.ms/deploytoazurebutton" alt="Deploy To Azure" style="max-width: 100%;" rel="noopener noreferrer" target="_blank"></a>
 <a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fappvia%2Fwayfinder-azure%2Fmaster%2Farm-template%2Fazuredeploy.json" rel="nofollow"><img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true" alt="Visualize" style="max-width: 100%;" target="_blank"></a></p>
 
+### Validating Template changes
+
+If making changes to the ARM templates, run the test suite in the ARM Template Testing Toolkit to make sure the templates are valid and unlikely to have issues when being submitted to the Marketplace. See [here]() for more details on the toolkit tests, but to run the tests you will need to have PowerShell installed, and the toolkit downloaded so the relevant modules can be imported into PowerShell:
+
+#### Download Powershell
+
+On MacOS, the simplest way is to install via `brew`:
+
+```shell
+$ brew install --cask powershell
+```
+
+And from here, `pwsh` will fork a new PowerShell process. Rejoice!
+
+>For other platforms, see [here](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.2).
+
+
+#### Download the testing toolkit
+
+The ARM Template Testing Toolkit (ttk) can be downloaded [here](https://aka.ms/arm-ttk-latest). Just download the zip, and unzip somewhere sensible.
+
+More information about the toolkit can be found at https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/test-toolkit
+
+#### Run the tests
+
+Running the tests is straightforward. Ensure you are in the PowerShell (`pwsh` from Bash and friends), and in the `wayfinder-azure/arm-template` directory, then:
+
+```powershell
+# The following imports the testing module into PowerShell
+PS /Path/To/wayfinder-azure/arm-tamplate> Import-Module </Path/To/testing/toolkit>/arm-ttk/arm-ttk.psd1
+# The following runs the testing toolkit tests
+PS /Path/To/wayfinder-azure/arm-tamplate> Test-AzTemplate -TemplatePath .
+```
+
 ### Post Install Steps
 
 After installation you must follow these steps to logon and set a password:

--- a/arm-template/README.md
+++ b/arm-template/README.md
@@ -12,40 +12,6 @@ This template deploys [Wayfinder](https://www.appvia.io/wayfinder). Wayfinder pr
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fappvia%2Fwayfinder-azure%2Fmaster%2Farm-template%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fappvia%2Fwayfinder-azure%2Fmaster%2Farm-template%2FcreateUiDefinition.json" rel="nofollow"><img src="https://aka.ms/deploytoazurebutton" alt="Deploy To Azure" style="max-width: 100%;" rel="noopener noreferrer" target="_blank"></a>
 <a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fappvia%2Fwayfinder-azure%2Fmaster%2Farm-template%2Fazuredeploy.json" rel="nofollow"><img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true" alt="Visualize" style="max-width: 100%;" target="_blank"></a></p>
 
-### Validating Template changes
-
-If making changes to the ARM templates, run the test suite in the ARM Template Testing Toolkit to make sure the templates are valid and unlikely to have issues when being submitted to the Marketplace. See [here]() for more details on the toolkit tests, but to run the tests you will need to have PowerShell installed, and the toolkit downloaded so the relevant modules can be imported into PowerShell:
-
-#### Download Powershell
-
-On MacOS, the simplest way is to install via `brew`:
-
-```shell
-$ brew install --cask powershell
-```
-
-And from here, `pwsh` will fork a new PowerShell process. Rejoice!
-
->For other platforms, see [here](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.2).
-
-
-#### Download the testing toolkit
-
-The ARM Template Testing Toolkit (ttk) can be downloaded [here](https://aka.ms/arm-ttk-latest). Just download the zip, and unzip somewhere sensible.
-
-More information about the toolkit can be found at https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/test-toolkit
-
-#### Run the tests
-
-Running the tests is straightforward. Ensure you are in the PowerShell (`pwsh` from Bash and friends), and in the `wayfinder-azure/arm-template` directory, then:
-
-```powershell
-# The following imports the testing module into PowerShell
-PS /Path/To/wayfinder-azure/arm-tamplate> Import-Module </Path/To/testing/toolkit>/arm-ttk/arm-ttk.psd1
-# The following runs the testing toolkit tests
-PS /Path/To/wayfinder-azure/arm-tamplate> Test-AzTemplate -TemplatePath .
-```
-
 ### Post Install Steps
 
 After installation you must follow these steps to logon and set a password:

--- a/arm-template/azuredeploy.json
+++ b/arm-template/azuredeploy.json
@@ -32,6 +32,10 @@
     "utcValue": {
       "type": "string",
       "defaultValue": "[utcNow()]"
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2_v2"
     }
   },
   "variables": {
@@ -116,7 +120,7 @@
             "count": 3,
             "minCount": 1,
             "maxCount": 10,
-            "vmSize": "Standard_D2_v2",
+            "vmSize": "[parameters('vmSize')]",
             "osType": "Linux",
             "mode": "System",
             "enableAutoScaling": true
@@ -191,11 +195,11 @@
       "type": "string",
       "value": "[reference(resourceId('Microsoft.Resources/deploymentScripts', 'wayfinder')).outputs.PostInstallCommands.firstLogin]"
     },
-    "ChangePassword": {
+    "ChangeLoginCredentials": {
       "type": "string",
       "value": "[reference(resourceId('Microsoft.Resources/deploymentScripts', 'wayfinder')).outputs.PostInstallCommands.changePassword]"
     },
-    "InitialPassword": {
+    "InitialLoginCredentials": {
       "type": "string",
       "value": "[reference(resourceId('Microsoft.Resources/deploymentScripts', 'wayfinder')).outputs.User.Password]"
     },

--- a/arm-template/createUiDefinition.json
+++ b/arm-template/createUiDefinition.json
@@ -40,6 +40,7 @@
                 "name": "clusterName",
                 "type": "Microsoft.Common.TextBox",
                 "label": "Specify the name of the Wayfinder installation (AKS cluster name)",
+                "toolTip": "The name of the cluster Wayfinder will be installed into",
                 "defaultValue": "wayfinder",
                 "constraints": {
                     "required": true,
@@ -163,6 +164,7 @@
                         "name": "legalAccept",
                         "type": "Microsoft.Common.CheckBox",
                         "label": "I agree to the terms and conditions for the license or I do not have a free license.",
+                        "toolTip": "Whether you agree to the required terms and conditions",
                         "constraints": {
                             "required": true,
                             "validationMessage": "Please acknowledge the legal conditions."


### PR DESCRIPTION
Jira: https://appviakore.atlassian.net/browse/WF-1119

Updates the `azuredeploy.json` and `createUiDefinition.json` to pass tests. Specifically:

- Adds testing details to `arm-templates/README.md`
- Added tool tips to the cluster name and accept legals form elements, in `createUiDefinition.json`
- Change the `vmSize` used in the ManagedCluster resource definition to be a parameter (this is just hard-coded in the parameters section, and not derived from any user input. However, the TTK tests require it to be a parameter 🤷‍♂️ )
- Changed the `ChangePassword` and `InitialPassword` output names to clear secrets-related tests