### PR TITLE
WF-1196: Remove email from Marketplace UI, and autogenerate it from subID & instanceID

### DIFF
--- a/arm-template/azuredeploy.json
+++ b/arm-template/azuredeploy.json
@@ -15,13 +15,6 @@
         "description": "The location of the Managed Cluster resource."
       }
     },
-    "email": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Email address (required to generate a free license if you do not have one)"
-      }
-    },
     "license": {
       "type": "string",
       "defaultValue": "",
@@ -46,7 +39,8 @@
     "aksRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
     "wfInstallIdentity": "wayfinderInstaller",
     "ingressIPName": "[concat(parameters('clusterName'), '-ingress')]",
-    "wfInstanceID": "[uniqueString(resourceGroup().id)]"
+    "wfInstanceID": "[uniqueString(resourceGroup().id)]",
+    "email": "[concat(subscription().subscriptionId, '.', variables('wfInstanceID'), '@appvia.io')]"
   },
   "resources": [
     {
@@ -169,7 +163,7 @@
           },
           {
             "name": "WF_EMAIL",
-            "value": "[parameters('email')]"
+            "value": "[variables('email')]"
           },
           {
             "name": "WF_LICENSE",

--- a/arm-template/createUiDefinition.json
+++ b/arm-template/createUiDefinition.json
@@ -55,23 +55,11 @@
                 "label": "Select License Type",
                 "elements":[
                     {
-                        "name": "announcement",
-                        "type": "Microsoft.Common.TextBlock",
-                        "visible": true,
-                        "options": {
-                            "text": "Provide a valid email address for a new free license, or provide your own license key",
-                            "link": {
-                                "label": "Learn more",
-                                "uri": "https://www.appvia.io/wayfinder-free"
-                            }
-                        }
-                    },
-                    {
-                        "name": "newFreeLicense",
+                        "name": "haveExistingLicense",
                         "type": "Microsoft.Common.OptionsGroup",
-                        "label": "Sign up for a new free license?",
+                        "label": "Do you have an existing license to apply to the Wayfinder installation?",
                         "defaultValue": true,
-                        "toolTip": "Sign up for a new free license (specify no if you have an existing free or other license)",
+                        "toolTip": "Select 'yes' if you already have a license, otherwise a new free license will be provisioned",
                         "constraints": {
                             "allowedValues": [
                                 {
@@ -88,38 +76,10 @@
                         "visible": true
                     },
                     {
-                        "name": "freeLicense",
-                        "label": "Free License",
-                        "type": "Microsoft.Common.Section",
-                        "visible": "[equals(steps('license').newFreeLicense, true)]",
-                        "elements": [
-                            {
-                                "name": "announcement",
-                                "type": "Microsoft.Common.TextBlock",
-                                "visible": true,
-                                "options": {
-                                    "text": "Wayfinder will not install if the email cannot be used for a license"
-                                }
-                            },
-                            {
-                                "name": "email",
-                                "type": "Microsoft.Common.TextBox",
-                                "label": "Free License Email",
-                                "defaultValue": "",
-                                "toolTip": "Please enter a valid email account",
-                                "constraints": {
-                                    "required": true,
-                                    "regex": "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
-                                    "validationMessage": "Email is not valid. Please re-enter."
-                                }
-                            }
-                        ]
-                    },
-                    {
                         "name": "existingLicense",
                         "label": "Existing License",
                         "type": "Microsoft.Common.Section",
-                        "visible": "[equals(steps('license').newFreeLicense, false)]",
+                        "visible": "[equals(steps('license').haveExistingLicense, true)]",
                         "elements": [
                             {
                                 "name": "announcement",
@@ -139,6 +99,21 @@
                                     "required": true,
                                     "regex": "^key\/.{500,700}$",
                                     "validationMessage": "License Key must be in the correct format. Please re-enter."
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "name": "noExistingLicense",
+                        "type": "Microsoft.Common.Section",
+                        "visible": "[equals(steps('license').haveExistingLicense, false)]",
+                        "elements": [
+                            {
+                                "name": "announcement",
+                                "type": "Microsoft.Common.TextBlock",
+                                "visible": true,
+                                "options": {
+                                    "text": "A free tier license will be provisioned as part of the installation."
                                 }
                             }
                         ]
@@ -211,7 +186,6 @@
         "outputs": {
             "location": "[location()]",
             "clusterName": "[basics('clusterName')]",
-            "email": "[steps('license').freeLicense.email]",
             "license": "[steps('license').existingLicense.key]",
             "jitAccessPolicy": "[steps('jitConfiguration').jitConfigurationControl]"
         }


### PR DESCRIPTION
Jira: https://appviakore.atlassian.net/browse/WF-1196

* Removes email field from the marketplace UI
* Flips the questions for the license to make the flow a little cleaner:

  * The UI now asks if you have a license key, then prompts for it if you do.   
  * If you answer "no", it displays a message notifying you a free-tier license will be generated

* Modify the template to generate an email for licensing based on [subscriptionID].[instanceID]@appvia.io

  * The deployment script is unchanged, and works with EITHER a license key, or an email - with license taking precedence