### PR TITLE
Add strip-license target; also extract zip packaging into own target

### DIFF
--- a/arm-template/createUiDefinition.json
+++ b/arm-template/createUiDefinition.json
@@ -176,7 +176,6 @@
                     {
                         "name": "legalAcceptSLA",
                         "type": "Microsoft.Common.CheckBox",
-                        "visible": "[equals(steps('license').newFreeLicense, true)]",
                         "label": "<a href=\"https://www.appvia.io/software-license-agreement-free?utm_campaign=Azure%20Marketplace&utm_source=web&utm_medium=Github&utm_term=Azure%20Marketplace&utm_content=Licence%20agreement\">Software License Agreement</a>",
                         "toolTip": "Whether you agree to the required Software License Agreement",
                         "constraints": {


### PR DESCRIPTION
Jira: https://appviakore.atlassian.net/browse/WF-1196

Third time's the charm :) Strips the License step from the UI definitions; this is done on both `create-appvia-package` and `create-external-package` targets.

Also extracts zipping up in its own target to reduce a bit of duplication.