### PR TITLE
Remove JIT access

### DIFF
--- a/arm-template/createUiDefinition.json
+++ b/arm-template/createUiDefinition.json
@@ -146,23 +146,6 @@
                 ]
             },
             {
-                "name": "jitConfiguration",
-                "label": "Just-In-Time Access",
-                "subLabel": {
-                    "preValidation": "Configure JIT settings for your application",
-                    "postValidation": "Done"
-                },
-                "bladeTitle": "JIT Configuration",
-                "elements": [
-                    {
-                      "name": "jitConfigurationControl",
-                      "type": "Microsoft.Solutions.JitConfigurator",
-                      "label": "JIT Configuration",
-                      "toolTip": "JIT Access enables Appvia Support to request elevated access to your Wayfinder installation for troubleshooting, rather than having full access by default."
-                    }
-                ]
-            },
-            {
                 "name": "acceptLegal",
                 "label": "Legal Agreements",
                 "elements": [
@@ -211,8 +194,7 @@
             "location": "[location()]",
             "clusterName": "[basics('clusterName')]",
             "email": "[steps('license').freeLicense.email]",
-            "license": "[steps('license').existingLicense.key]",
-            "jitAccessPolicy": "[steps('jitConfiguration').jitConfigurationControl]"
+            "license": "[steps('license').existingLicense.key]"
         }
     }
 }


### PR DESCRIPTION
JIT Access only works if individual users are added within the Technical Configuration for a Plan within an Offer. Additionally, we can't enforce JIT Access to always be enabled for Customers. So for consistency across installs and ease of management (access via an AAD Group) this is being removed.