### PR TITLE
Upgrade using arm template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Sessionx.vim
 .build
 .env
 parameters.json
+scriptoutputs.json

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,4 @@ Sessionx.vim
 # Build and Test files
 .build
 .env
-scriptoutputs.json
-wf-parameters.env
+parameters.json

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,9 @@ create-appvia-package: create-build-dir copy-to-build-dir strip-license
 	jq \
 		'walk(if type == "object" then with_entries(select(.key | test("delegatedManagedIdentityResourceId") | not)) else . end) | \
 		.parameters.partnerId.defaultValue = "${TRACKING_ID}" | \
+		.parameters.wfPlanId.defaultValue = "${WF_PLAN_ID}" | \
 		.parameters.version.defaultValue = "${WF_VERSION}" | \
-		.parameters.releases.defaultValue = "${WF_RELEASE_CHANNEL}" | \
-		.variables.wfPlanID = "${WF_PLAN_ID}"' \
+		.parameters.releases.defaultValue = "${WF_RELEASE_CHANNEL}"' \
 		${BUILD_DIR}/azuredeploy.json > ${BUILD_DIR}/mainTemplate.json
 
 	$(MAKE) package
@@ -45,9 +45,9 @@ create-external-package: create-build-dir copy-to-build-dir strip-license
 	@echo "--> Creating a package for external tenants"
 	jq \
 		'.parameters.partnerId.defaultValue = "${TRACKING_ID}" | \
+		.parameters.wfPlanId.defaultValue = "${WF_PLAN_ID}" | \
 		.parameters.version.defaultValue = "${WF_VERSION}" | \
-		.parameters.releases.defaultValue = "${WF_RELEASE_CHANNEL}" | \
-		.variables.wfPlanID = "${WF_PLAN_ID}"' \
+		.parameters.releases.defaultValue = "${WF_RELEASE_CHANNEL}"' \
 		${BUILD_DIR}/azuredeploy.json > ${BUILD_DIR}/mainTemplate.json
 
 	@$(MAKE) package

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ create-appvia-package: create-build-dir copy-to-build-dir strip-license
 	@echo "--> Creating a package for internal testing within an Appvia Tenant"
 	jq \
 		'walk(if type == "object" then with_entries(select(.key | test("delegatedManagedIdentityResourceId") | not)) else . end) | \
+		.parameters.partnerId.defaultValue = "${TRACKING_ID}" | \
 		.parameters.version.defaultValue = "${WF_VERSION}" | \
 		.parameters.releases.defaultValue = "${WF_RELEASE_CHANNEL}" | \
-		.variables.wfPlanID = "${WF_PLAN_ID}" | \
-		.resources[0].name = "${TRACKING_ID}"' \
+		.variables.wfPlanID = "${WF_PLAN_ID}"' \
 		${BUILD_DIR}/azuredeploy.json > ${BUILD_DIR}/mainTemplate.json
 
 	$(MAKE) package
@@ -44,10 +44,10 @@ create-appvia-package: create-build-dir copy-to-build-dir strip-license
 create-external-package: create-build-dir copy-to-build-dir strip-license
 	@echo "--> Creating a package for external tenants"
 	jq \
-		'.parameters.version.defaultValue = "${WF_VERSION}" | \
+		'.parameters.partnerId.defaultValue = "${TRACKING_ID}" | \
+		.parameters.version.defaultValue = "${WF_VERSION}" | \
 		.parameters.releases.defaultValue = "${WF_RELEASE_CHANNEL}" | \
-		.variables.wfPlanID = "${WF_PLAN_ID}" | \
-		.resources[0].name = "${TRACKING_ID}"' \
+		.variables.wfPlanID = "${WF_PLAN_ID}"' \
 		${BUILD_DIR}/azuredeploy.json > ${BUILD_DIR}/mainTemplate.json
 
 	@$(MAKE) package

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEMPLATE_DIR=arm-template
 WF_VERSION ?= latest
 WF_RELEASE_CHANNEL ?= releases
 WF_PLAN_ID ?= wayfinder-standard
-TRACKING_ID ?= pid-d67dc5ed-2255-482d-8bdb-5c81425b3d83-partnercenter
+TRACKING_ID ?= pid-3b0884cf-abb0-46cf-a48b-55ee7245e8a9-partnercenter
 
 create-build-dir:
 	@echo "--> Creating build directory"
@@ -27,10 +27,10 @@ create-appvia-package: create-build-dir copy-to-build-dir strip-license
 	@echo "--> Creating a package for internal testing within an Appvia Tenant"
 	jq \
 		'walk(if type == "object" then with_entries(select(.key | test("delegatedManagedIdentityResourceId") | not)) else . end) | \
-		.parameters.partnerId.defaultValue = "${TRACKING_ID}" | \
 		.parameters.wfPlanId.defaultValue = "${WF_PLAN_ID}" | \
 		.parameters.version.defaultValue = "${WF_VERSION}" | \
-		.parameters.releases.defaultValue = "${WF_RELEASE_CHANNEL}"' \
+		.parameters.releases.defaultValue = "${WF_RELEASE_CHANNEL}" | \
+		.resources[0].name = "${TRACKING_ID}"' \
 		${BUILD_DIR}/azuredeploy.json > ${BUILD_DIR}/mainTemplate.json
 
 	$(MAKE) package
@@ -38,10 +38,10 @@ create-appvia-package: create-build-dir copy-to-build-dir strip-license
 create-external-package: create-build-dir copy-to-build-dir strip-license
 	@echo "--> Creating a package for external tenants"
 	jq \
-		'.parameters.partnerId.defaultValue = "${TRACKING_ID}" | \
-		.parameters.wfPlanId.defaultValue = "${WF_PLAN_ID}" | \
+		'.parameters.wfPlanId.defaultValue = "${WF_PLAN_ID}" | \
 		.parameters.version.defaultValue = "${WF_VERSION}" | \
-		.parameters.releases.defaultValue = "${WF_RELEASE_CHANNEL}"' \
+		.parameters.releases.defaultValue = "${WF_RELEASE_CHANNEL}" | \
+		.resources[0].name = "${TRACKING_ID}"' \
 		${BUILD_DIR}/azuredeploy.json > ${BUILD_DIR}/mainTemplate.json
 
 	@$(MAKE) package

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,6 @@ strip-license:
 		del(.parameters.outputs.email) | \
 		del(.parameters.outputs.license)' \
 		${TEMPLATE_DIR}/createUiDefinition.json > ${BUILD_DIR}/createUiDefinition.json
-	jq \
-		'del(.parameters.email) | \
-		del(.parameters.license) | \
-		del(.. | .environmentVariables? // empty | .[] | select(.name == "WF_LICENSE_EMAIL")) | \
-		del(.. | .environmentVariables? // empty | .[] | select(.name == "WF_LICENSE_KEY"))' \
-		${TEMPLATE_DIR}/azuredeploy.json > ${BUILD_DIR}/azuredeploy.json
 
 create-appvia-package: create-build-dir copy-to-build-dir strip-license
 	@echo "--> Creating a package for internal testing within an Appvia Tenant"

--- a/arm-template/azuredeploy.json
+++ b/arm-template/azuredeploy.json
@@ -9,6 +9,13 @@
         "description": "The Azure Marketplace usage attribution tracking GUID"
       }
     },
+    "wfPlanId": {
+      "type": "string",
+      "defaultValue": "wayfinder-standard",
+      "metadata": {
+        "description": "The Azure Marketplace Wayfinder Offer Plan ID"
+      }
+    },
     "clusterName": {
       "type": "string",
       "defaultValue": "wayfinder",
@@ -71,7 +78,6 @@
     "managedIdentityWFInstaller": "wayfinder-installer",
     "managedIdentityWF": "wayfinder-default",
     "deploymentWFInstaller": "wayfinder-installer",
-    "wfPlanID": "wayfinder-standard",
     "wfDimension": "vcpu",
     "deploymentGetAKSMI": "wayfinder-get-aks-mi",
     "deploymentNRGAccess": "wayfinder-node-resource-group-access",
@@ -364,7 +370,7 @@
           },
           {
             "name": "WF_PLAN_ID",
-            "value": "[variables('wfPlanID')]"
+            "value": "[parameters('wfPlanId')]"
           },
           {
             "name": "WF_DIMENSION",

--- a/arm-template/azuredeploy.json
+++ b/arm-template/azuredeploy.json
@@ -2,13 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "partnerId": {
-      "type": "string",
-      "defaultValue": "pid-d67dc5ed-2255-482d-8bdb-5c81425b3d83-partnercenter",
-      "metadata": {
-        "description": "The Azure Marketplace usage attribution tracking GUID"
-      }
-    },
     "wfPlanId": {
       "type": "string",
       "defaultValue": "wayfinder-standard",
@@ -91,7 +84,7 @@
       "comments": "*** Azure Marketplace required usage attribution tracking GUID ***",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2021-04-01",
-      "name": "[parameters('partnerId')]",
+      "name": "pid-188392e6-9687-4e00-8c58-904709546b4a",
       "properties": {
         "mode": "Incremental",
         "template": {

--- a/arm-template/azuredeploy.json
+++ b/arm-template/azuredeploy.json
@@ -2,8 +2,16 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "partnerId": {
+      "type": "string",
+      "defaultValue": "pid-d67dc5ed-2255-482d-8bdb-5c81425b3d83-partnercenter",
+      "metadata": {
+        "description": "The Azure Marketplace usage attribution tracking GUID"
+      }
+    },
     "clusterName": {
       "type": "string",
+      "defaultValue": "wayfinder",
       "metadata": {
         "description": "The name of the Wayfinder management cluster."
       }
@@ -77,7 +85,7 @@
       "comments": "*** Azure Marketplace required usage attribution tracking GUID ***",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2021-04-01",
-      "name": "pid-d67dc5ed-2255-482d-8bdb-5c81425b3d83-partnercenter",
+      "name": "[parameters('partnerId')]",
       "properties": {
         "mode": "Incremental",
         "template": {

--- a/arm-template/scripts/upgrade.sh
+++ b/arm-template/scripts/upgrade.sh
@@ -14,51 +14,87 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 set -o errexit
 set -o pipefail
 ${TRACE:+set -x}
 
 # Get script current directory
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-PARAMETERS_FILE="wf-parameters.env"
 
-error_exit() {
-    echo "Error: ${1}"
-    exit 1
+# Default variables
+PARAMETERS_FILE="${SCRIPT_DIR}/parameters.json"
+DEFAULT_RELEASE_VERSION="main"
+FLAG_SUBSCRIPTION=""
+FLAG_RESOURCE_GROUP=""
+FLAG_NAME="${DEFAULT_APP_NAME}"
+FLAG_RELEASE="${DEFAULT_RELEASE_VERSION}"
+
+# Help instructions for this script.
+print_usage() {
+  printf "\nUSAGE: $0 [flags]
+
+Flags:
+  -s  The Subscription ID where the Resource Group for the Managed Application exists (default: none)
+  -g  The Resource Group where the Managed Application lives (default: none)
+  -n  The name of the Managed Application (default: none)
+  -r  The branch name or tag of the Wayfinder Azure release to deploy (default: '${DEFAULT_RELEASE_VERSION}')
+  -h  show this help\n"
 }
 
-# Check that Managed Resource Group ID was provided
-check_arg() {
-    if [ -z "$1" ]
-    then
-        error_exit "No argument supplied. A Managed Resource Group ID must be provided, e.g. : $(basename $0) mrg-wayfinder-20220101150000"
-    fi
-}
-
-fetch_parameters() {
-    # Create an empty env file with parameters for the installer
-    echo "" > ${PARAMETERS_FILE}
-
-    # Fetch environment variables that were passed to the deployment script
-    variables=$(az deployment-scripts show --name wayfinder-installer --resource-group $1 --query environmentVariables)
-
-    # Create a parameters file
-    echo $variables | jq -c '.[]' | while read i; do
-        key=$(echo $i | jq -r '.name')
-        value=$(echo $i | jq -r '.value')
-        echo "export $key=$value" >> ${PARAMETERS_FILE}
+# Check that all required arguments have been supplied.
+check_required_arguments() {
+    for var in "FLAG_SUBSCRIPTION" "FLAG_RESOURCE_GROUP" "FLAG_NAME" "FLAG_RELEASE"; do
+        if [ -z "${!var}" ]; then
+            echo "Error: Variable ${var} has no value."
+            print_usage
+            exit 1
+        fi
     done
 }
 
+# Fetch parameters originally provided to the Managed Application at time of installation.
+# TODO: For future-proofing, we should implement a parameter store and fetch parameters from that.
+#       The Managed Application parameters are fixed at time of installation, so the parameter store
+#       can be used to keep track of any new additions and supply it to the ARM template
+fetch_parameters() {
+    parameters=$(az managedapp show --subscription ${FLAG_SUBSCRIPTION} -g ${FLAG_RESOURCE_GROUP} -n ${FLAG_NAME} --query parameters)
+
+    # Remove the type key and generate a json file with the parameters
+    echo $parameters | jq 'walk(if type == "object" then with_entries(select(.key | test("type") | not)) else . end)' > ${PARAMETERS_FILE}
+}
+
+# Fetch the name of the Managed Resource Group where the Wayfinder resources reside.
+fetch_mrg_name() {
+    az managedapp show --subscription ${FLAG_SUBSCRIPTION} -g ${FLAG_RESOURCE_GROUP} -n ${FLAG_NAME} -o tsv --query managedResourceGroupId | sed 's/.*\///'
+}
+
+# Perform an upgrade of the Managed Application by redeploying the ARM Template at a specified version.
 upgrade() {
-    source ${PARAMETERS_FILE} && bash ${SCRIPT_DIR}/wayfinder.sh
+    timestamp=$(date +%Y%m%d-%H%M%S)
+    az deployment group create --name wf-upgrade-${timestamp}-${FLAG_RELEASE} --resource-group ${1} --template-uri https://raw.githubusercontent.com/appvia/wayfinder-azure/${FLAG_RELEASE}/arm-template/azuredeploy.json --parameters @${PARAMETERS_FILE}
 }
 
+# The main function
 main() {
-    check_arg ${1}
-    fetch_parameters ${1}
-    upgrade
+    check_required_arguments
+    fetch_parameters
+    mrg=$(fetch_mrg_name)
+    upgrade $mrg
 }
 
-main ${1}
+
+# Parse arguments provided to the script and error if any are unexpected
+while getopts 's:g:n:r:h' flag; do
+    case "${flag}" in
+        s) FLAG_SUBSCRIPTION="${OPTARG}" ;;
+        g) FLAG_RESOURCE_GROUP="${OPTARG}" ;;
+        n) FLAG_NAME="${OPTARG}" ;;
+        r) FLAG_RELEASE="${OPTARG}" ;;
+        h) print_usage && exit 0 ;;
+        *) print_usage
+        exit 1 ;;
+    esac
+done
+
+# Run the main function
+main

--- a/arm-template/scripts/wayfinder.sh
+++ b/arm-template/scripts/wayfinder.sh
@@ -79,9 +79,9 @@ check-envs() {
     ; do check_var ${var:-}
   done
 
-  if [[ -n ${WF_LICENSE_KEY:-} ]]; then
+  if [[ ! -z "${WF_LICENSE_KEY}" ]]; then
     LICENSE_OPT="--license-key ${WF_LICENSE_KEY}"
-  elif [[ -n ${WF_LICENSE_EMAIL:-} ]]; then
+  elif [[ ! -z "${WF_LICENSE_EMAIL}" ]]; then
     LICENSE_OPT="--license-email ${WF_LICENSE_EMAIL}"
   fi
 }


### PR DESCRIPTION
The upgrade script has been updated to re-run the ARM template against a version in the repository, using the parameters initially used and stored against the details of the Managed Application.

**NOTE:** If an application was originally installed using a template that has been modified (e.g. via the Makefile commands, does not match the contents in `arm-template/azuredeploy.json`), there could be conflicts or issues that arise due to the differences in the installation process (e.g. installing without license flags).